### PR TITLE
Fix dual docs deployment and add version display

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,6 +54,13 @@ jobs:
       run: |
         echo "QUARTO_PYTHON=$(uv run which python)" >> $GITHUB_ENV
 
+    - name: Extract version from pyproject.toml
+      id: version
+      run: |
+        VERSION=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "📦 Version: $VERSION"
+
     - name: Generate API Documentation
       run: |
         uv run python scripts/update_docs.py
@@ -66,13 +73,13 @@ jobs:
       if: github.ref == 'refs/heads/main'
       run: |
         cd docs
-        uv run quarto render --profile main
+        uv run quarto render --profile main -M version:"${{ steps.version.outputs.version }}"
 
     - name: Render Quarto Documentation (dev)
       if: github.ref == 'refs/heads/dev'
       run: |
         cd docs
-        uv run quarto render --profile dev
+        uv run quarto render --profile dev -M version:"${{ steps.version.outputs.version }}-dev"
 
     - name: Merge with existing gh-pages
       if: github.event_name != 'pull_request'

--- a/docs/_quarto-main.yml
+++ b/docs/_quarto-main.yml
@@ -1,4 +1,4 @@
 # Main deployment profile
 # Deploys to root path on GitHub Pages
-site:
+website:
   site-path: "/"

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -23,6 +23,7 @@ website:
       - href: cli-reference/index.qmd
         text: CLI Reference
     right:
+      - text: "{{< meta version >}}"
       - href: https://github.com/kompre/keecas
         text: GitHub
         aria-label: GitHub


### PR DESCRIPTION
## Summary
- Fixes inconsistent Quarto profile configuration preventing simultaneous main + dev docs
- Adds automatic version display in navbar from `pyproject.toml`

## Changes
1. **Profile consistency**: Changed `_quarto-main.yml` to use `website:` key (was using deprecated `site:`)
2. **Version extraction**: Docs workflow now extracts version from `pyproject.toml` using `tomllib`
3. **Version display**: Navbar shows version with `-dev` suffix for dev deployments

## Why This Fixes the Issue
The root cause was mixing `site:` (deprecated) and `website:` keys between profiles, causing Quarto to generate conflicting base path configurations. This made GitHub Pages serve only the last-rendered version instead of coexisting at `/` and `/dev`.

## Testing
- Merge to dev → verify dev docs appear at `/dev` subdirectory
- Merge to main → verify both `/` (main) and `/dev` remain accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)