### PR TITLE
fix: Preserve both main and dev docs in dual deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
+  group: "pages-${{ github.ref }}"  # Separate concurrency per branch
   cancel-in-progress: false
 
 jobs:
@@ -116,9 +116,25 @@ jobs:
             echo "✅ Backed up /dev directory"
           fi
 
-          # Clear root and copy new main docs
-          rm -rf /tmp/gh-pages-staged/*
+          # Backup hidden files (.nojekyll, etc.)
+          shopt -s dotglob  # Enable dotglob to match hidden files
+          mkdir -p /tmp/hidden-backup
+          for file in /tmp/gh-pages-staged/.*; do
+            if [ -f "$file" ]; then
+              cp "$file" /tmp/hidden-backup/
+            fi
+          done
+
+          # Clear root (visible files only, preserve hidden)
+          find /tmp/gh-pages-staged -mindepth 1 -maxdepth 1 ! -name '.*' -exec rm -rf {} +
+
+          # Copy new main docs
           cp -r docs/_site/* /tmp/gh-pages-staged/
+
+          # Restore hidden files
+          if [ -d "/tmp/hidden-backup" ]; then
+            cp /tmp/hidden-backup/.* /tmp/gh-pages-staged/ 2>/dev/null || true
+          fi
 
           # Restore dev directory
           if [ -d "/tmp/dev-backup" ]; then
@@ -140,6 +156,10 @@ jobs:
         echo "✅ Staged docs for deployment"
         echo "📊 Contents:"
         ls -la /tmp/gh-pages-staged/
+        if [ -d "/tmp/gh-pages-staged/dev" ]; then
+          echo "📊 Dev directory contents:"
+          ls -la /tmp/gh-pages-staged/dev/ | head -n 10
+        fi
 
     - name: Upload merged artifact
       uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Problem
Dual documentation deployment was broken - deploying from one branch would erase the other:
- Deploy from main → /dev directory disappeared (404 at /dev)  
- Deploy from dev → root directory disappeared (404 at /)

## Root Causes

1. **Concurrency group conflict** (CRITICAL):
   - Single group: pages for all branches
   - main and dev workflows could race/overwrite each other
   - Last deployment wins, replaces the first

2. **Hidden files not preserved**:
   - rm -rf /tmp/gh-pages-staged/* glob does not match .nojekyll
   - Hidden files lost during deployment

3. **Backup logic fragile**:
   - Concept was correct but execution had gaps

## Solution

### Fix 1: Per-Branch Concurrency
- Changed concurrency group to pages-${{ github.ref }}
- main and dev get independent locks
- No race conditions between branches

### Fix 2: Safe File Handling
- Explicitly backup hidden files before clearing root
- Use find command instead of glob for deletion
- Restore both dev directory AND hidden files

### Fix 3: Enhanced Logging
- Verify /dev directory exists after merge
- Debug deployment issues faster

## Result

Both documentation versions accessible simultaneously:
- **Stable (main)**: https://username.github.io/keecas/
- **Development (dev)**: https://username.github.io/keecas/dev/

## Testing Plan

After merge:
1. Push small change to main → verify /dev preserved
2. Push small change to dev → verify / preserved
3. Check CI logs for backup/restore verification messages

## Changes
- Modified .github/workflows/docs.yml:
  - Changed concurrency group from pages to pages-${{ github.ref }}
  - Added hidden file backup/restore logic
  - Improved root clearing with find command
  - Added dev directory verification logging