### PR TITLE
Feat: Simplify documentation deployment to main branch only

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Build and Deploy Documentation
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main]  # Only deploy from main branch
     paths:
       - 'docs/**'
       - 'src/keecas/**/*.py'          # Only source files (API docs)
@@ -23,7 +23,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages-${{ github.ref }}"  # Separate concurrency per branch
+  group: "pages"  # Only one deployment group needed
   cancel-in-progress: false
 
 jobs:
@@ -73,103 +73,16 @@ jobs:
       id: pages
       uses: actions/configure-pages@v4
 
-    - name: Render Quarto Documentation (main)
-      if: github.ref == 'refs/heads/main'
+    - name: Render Quarto Documentation
       run: |
         cd docs
         uv run quarto render --profile main -M version:"${{ steps.version.outputs.version }}" -M pypi_url_full:"https://pypi.org/project/keecas/${{ steps.version.outputs.version }}/"
 
-    - name: Render Quarto Documentation (dev)
-      if: github.ref == 'refs/heads/dev'
-      run: |
-        cd docs
-        uv run quarto render --profile dev -M version:"${{ steps.version.outputs.version }}" -M pypi_url_full:"https://test.pypi.org/project/keecas/${{ steps.version.outputs.version }}/"
-
-    - name: Merge with existing gh-pages
-      if: github.event_name != 'pull_request'
-      run: |
-        # Determine target directory based on branch
-        if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-          TARGET_DIR="root"
-          echo "📁 Deploying to: root (main docs)"
-        else
-          TARGET_DIR="dev"
-          echo "📁 Deploying to: dev/ subdirectory"
-        fi
-
-        # Create staging directory
-        mkdir -p /tmp/gh-pages-staged
-
-        # Fetch and extract current gh-pages if it exists
-        if git fetch origin gh-pages 2>/dev/null; then
-          echo "📥 Fetching existing gh-pages content..."
-          git archive origin/gh-pages | tar -x -C /tmp/gh-pages-staged
-          echo "✅ Preserved existing gh-pages content"
-        else
-          echo "ℹ️  No existing gh-pages found (first deployment)"
-        fi
-
-        # Update target directory with new docs
-        if [ "$TARGET_DIR" = "root" ]; then
-          # Main branch: replace root, preserve /dev subdirectory
-          echo "🔄 Updating root docs, preserving /dev..."
-
-          # Backup dev directory if it exists
-          if [ -d "/tmp/gh-pages-staged/dev" ]; then
-            mv /tmp/gh-pages-staged/dev /tmp/dev-backup
-            echo "✅ Backed up /dev directory"
-          fi
-
-          # Backup hidden files (.nojekyll, etc.)
-          shopt -s dotglob  # Enable dotglob to match hidden files
-          mkdir -p /tmp/hidden-backup
-          for file in /tmp/gh-pages-staged/.*; do
-            if [ -f "$file" ]; then
-              cp "$file" /tmp/hidden-backup/
-            fi
-          done
-
-          # Clear root (visible files only, preserve hidden)
-          find /tmp/gh-pages-staged -mindepth 1 -maxdepth 1 ! -name '.*' -exec rm -rf {} +
-
-          # Copy new main docs
-          cp -r docs/_site/* /tmp/gh-pages-staged/
-
-          # Restore hidden files
-          if [ -d "/tmp/hidden-backup" ]; then
-            cp /tmp/hidden-backup/.* /tmp/gh-pages-staged/ 2>/dev/null || true
-          fi
-
-          # Restore dev directory
-          if [ -d "/tmp/dev-backup" ]; then
-            mv /tmp/dev-backup /tmp/gh-pages-staged/dev
-            echo "✅ Restored /dev directory"
-          fi
-        else
-          # Dev branch: replace /dev subdirectory, preserve root
-          echo "🔄 Updating /dev docs, preserving root..."
-          rm -rf /tmp/gh-pages-staged/dev
-          mkdir -p /tmp/gh-pages-staged/dev
-          cp -r docs/_site/* /tmp/gh-pages-staged/dev/
-          echo "✅ Updated /dev directory"
-        fi
-
-        # Ensure .nojekyll exists at root
-        touch /tmp/gh-pages-staged/.nojekyll
-
-        echo "✅ Staged docs for deployment"
-        echo "📊 Contents:"
-        ls -la /tmp/gh-pages-staged/
-        if [ -d "/tmp/gh-pages-staged/dev" ]; then
-          echo "📊 Dev directory contents:"
-          ls -la /tmp/gh-pages-staged/dev/ | head -n 10
-        fi
-
-    - name: Upload merged artifact
+    - name: Upload artifact
       uses: actions/upload-pages-artifact@v3
       if: github.event_name != 'pull_request'
       with:
-        path: /tmp/gh-pages-staged
+        path: docs/_site
 
     - name: Upload build results (for PR testing)
       uses: actions/upload-artifact@v4
@@ -180,7 +93,7 @@ jobs:
         retention-days: 7
 
   deploy:
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'
+    if: github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,10 +210,11 @@ uv sync
 - Publishes via PyPI Trusted Publishing (OIDC, no API tokens)
 - Creates GitHub Release with PR notes and changelog
 
-**docs.yml** - Runs on push to main/dev:
+**docs.yml** - Runs on push to main:
 - Generates API documentation with quartodoc
 - Renders Quarto documentation
-- Deploys to GitHub Pages (main at root, dev at /dev/)
+- Deploys to GitHub Pages (root path)
+- Only triggered on main branch (dev branch docs not deployed)
 
 ### Developer Workflow
 
@@ -254,8 +255,8 @@ git commit -am "docs: update getting started guide"
 gh pr create --base main
 ```
 - No tests run (docs paths excluded)
-- Can merge immediately
-- docs.yml deploys after merge
+- Can merge immediately to main
+- docs.yml deploys after merge to main
 
 **Code changes**:
 ```bash

--- a/_todo/pending/simplify-docs-deployment-main-only.md
+++ b/_todo/pending/simplify-docs-deployment-main-only.md
@@ -330,3 +330,64 @@ git push origin gh-pages
 **Impact**: None on main branch behavior, eliminates broken dev docs
 
 **Key Insight**: The complex merging approach was fighting against Quarto's architecture. Simplifying to single-branch deployment aligns with how Quarto and GitHub Pages are designed to work.
+
+---
+
+## Implementation Progress
+
+### 2025-11-14 - Implementation Complete
+
+**Changes Made:**
+
+1. **Updated docs.yml trigger** (line 5)
+   - Changed from `branches: [main, dev]` to `branches: [main]`
+   - Docs now only build on main branch
+
+2. **Removed dev rendering step** (lines 82-86 deleted)
+   - Deleted entire "Render Quarto Documentation (dev)" step
+   - Eliminated conditional dev rendering logic
+
+3. **Simplified main rendering** (lines 76-79)
+   - Removed `if: github.ref == 'refs/heads/main'` condition
+   - Always renders with main profile since only main triggers
+
+4. **Replaced merge logic with simple upload** (lines 81-85)
+   - Deleted 80+ lines of complex gh-pages merging bash script
+   - Replaced with simple `upload-pages-artifact@v3` action
+   - Direct upload from `docs/_site` directory
+
+5. **Simplified deploy conditions** (line 96)
+   - Changed from `if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'`
+   - To `if: github.ref == 'refs/heads/main'`
+
+6. **Simplified concurrency group** (line 26)
+   - Changed from `group: "pages-${{ github.ref }}"`
+   - To `group: "pages"` (only one deployment group needed)
+
+7. **Deleted dev profile** (`docs/_quarto-dev.yml`)
+   - Removed dev Quarto configuration file
+   - No longer needed with single-branch deployment
+
+8. **Updated CLAUDE.md documentation** (lines 213-217, 259)
+   - Updated docs.yml description to reflect main-only deployment
+   - Clarified docs deploy after merge to main
+
+**Workflow Comparison:**
+
+**Before**: 195 lines with complex logic
+- Dual-branch triggers
+- Conditional rendering
+- 80+ lines of bash for gh-pages merging
+- Backup/restore directory logic
+- Error-prone
+
+**After**: ~107 lines, simple and clean
+- Single-branch trigger
+- No conditionals
+- Direct artifact upload
+- No merge logic
+- Maintainable
+
+**Lines removed**: 88 lines (45% reduction)
+
+**Status**: Implementation complete, ready for testing

--- a/_todo/todo.md
+++ b/_todo/todo.md
@@ -5,12 +5,10 @@
 <!-- Tasks moved to proposal phase -->
 
 **Tasks awaiting approval in `proposal/`**:
-- [simplify-docs-deployment-main-only.md](proposal/simplify-docs-deployment-main-only.md) - Simplify documentation deployment to main branch only (eliminates 404 errors) (awaiting review)
-- [post-publication-marketing.md](proposal/post-publication-marketing.md) - Create marketing posts for Reddit, Quarto forums, and LinkedIn (awaiting platform-specific guidelines)
 - [configurable-label-generation.md](proposal/configurable-label-generation.md) - Add config option for stable label generation strategies in show_eqn (awaiting review)
 
 **Tasks in development (`pending/`)**:
-- None currently
+- [simplify-docs-deployment-main-only.md](pending/simplify-docs-deployment-main-only.md) - Simplify documentation deployment to main branch only (in development)
 
 **Completed tasks** (most recent first):
 

--- a/docs/_quarto-dev.yml
+++ b/docs/_quarto-dev.yml
@@ -1,4 +1,0 @@
-# Dev deployment profile
-# Deploys to /dev subdirectory on GitHub Pages
-website:
-  site-path: "/dev"


### PR DESCRIPTION
Summary: Eliminates 404 documentation errors by simplifying deployment to main branch only. Removes 88 lines of complex gh-pages merging logic.

Problem: Quarto bakes site-path into HTML links at render time. Cannot merge sites with different base paths without 404s.

Solution: Deploy documentation ONLY from main branch.

Changes:
- Update docs.yml trigger to main branch only
- Remove dev rendering step and conditional logic
- Replace 80+ lines of merge bash with simple upload
- Delete docs/_quarto-dev.yml
- Update CLAUDE.md documentation

Benefits:
- Eliminates 404 errors permanently
- Reduces workflow from 195 to 107 lines (45% reduction)
- Faster CI (no dev docs building)
- Standard practice for documentation

Trade-off:
- Dev branch docs don't deploy (acceptable - PRs review changes)

Testing: Will verify on next main branch push