### PR TITLE
fix(config): fix tomlkit string serialization and local config discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "tomlkit>=0.13.3",
 ]
 name = "keecas"
-version = "1.1.2"
+version = "1.1.3rc1"
 description = "Symbolic and units-aware calculations with LaTeX rendering for Jupyter notebooks, optimized for Quarto PDF documentation."
 readme = "README.md"
 

--- a/src/keecas/config/manager.py
+++ b/src/keecas/config/manager.py
@@ -456,7 +456,22 @@ class ConfigManager:
         return config_dir / "config.toml"
 
     def _get_local_config_path(self) -> Path:
-        """Get path to local configuration file."""
+        """Search upward from CWD for .keecas/config.toml, falling back to CWD.
+
+        This allows config to be found when running from a subdirectory of the project.
+        The global config path is excluded to avoid treating it as a local config.
+        """
+        current = Path.cwd()
+        while True:
+            candidate = current / ".keecas" / "config.toml"
+            if candidate == self._global_config_path:
+                break
+            if candidate.exists():
+                return candidate
+            parent = current.parent
+            if parent == current:  # Reached filesystem root
+                break
+            current = parent
         return Path.cwd() / ".keecas" / "config.toml"
 
     def load_configs(self) -> None:
@@ -495,10 +510,13 @@ class ConfigManager:
         config_version = metadata.get("config_version", "0.1.0")
         current_version = get_current_schema_version()
 
-        # Load actual config data - use tomlkit to preserve structure
+        # Load actual config data - use tomlkit to preserve structure for migration,
+        # but convert to native Python types via round-trip to avoid tomlkit wrapper
+        # types (e.g. tomlkit.items.String) being stored in config, which causes
+        # toml.dumps() to iterate strings as character sequences.
         with open(config_path, encoding="utf-8") as f:
             toml_doc = tomlkit.load(f)
-            config_data = dict(toml_doc)  # Convert to dict for migration
+            config_data = toml.loads(tomlkit.dumps(toml_doc))
 
         # Check if migration needed
         if ConfigMigration.needs_migration(config_version, current_version):

--- a/uv.lock
+++ b/uv.lock
@@ -877,7 +877,7 @@ wheels = [
 
 [[package]]
 name = "keecas"
-version = "1.1.2"
+version = "1.1.3rc1"
 source = { editable = "." }
 dependencies = [
     { name = "flatten-dict" },


### PR DESCRIPTION
## Summary
- Fix language values serialized as `["e", "s"]` instead of `"es"` — root cause was `dict(toml_doc)` leaving `tomlkit.items.String` wrappers in place, which `toml.dumps()` iterates as character sequences. Fixed with a `toml.loads(tomlkit.dumps(...))` round-trip.
- Fix local config not found when running from a project subdirectory (e.g. notebooks in `examples/`). `_get_local_config_path` now searches upward from CWD, stopping before the global `~/.keecas/config.toml`.
- Bump version to `1.1.3rc1`

## Test plan
- [ ] `keecas config show` displays `language = "es"` (not `["e", "s"]`)
- [ ] Running from a subdirectory still picks up the project-root `.keecas/config.toml`
- [ ] Existing test suite passes (214 tests, 1 pre-existing failure in test_pint_locale_initialization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)