### PR TITLE
Release v1.1.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,9 +26,17 @@ jobs:
       - name: Detect changed files
         id: changes
         run: |
+          BASE_REF="${{ github.base_ref }}"
+          if [ -z "$BASE_REF" ]; then
+            # Push event - base_ref is not set, always run full tests
+            echo "🔍 Push event - running full tests"
+            echo "docs_only=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           # Get list of changed files in this PR
-          git fetch origin ${{ github.base_ref }}
-          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          git fetch origin "$BASE_REF"
+          CHANGED_FILES=$(git diff --name-only "origin/$BASE_REF...HEAD")
 
           echo "Changed files:"
           echo "$CHANGED_FILES"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,12 @@ name: Run Tests
 on:
   pull_request:
     branches: [ main, dev ]
+  push:
+    branches: [ main, dev ]
+  workflow_dispatch:
 
 concurrency:
-  group: test-${{ github.event.pull_request.number }}
+  group: test-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 permissions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "tomlkit>=0.13.3",
 ]
 name = "keecas"
-version = "1.1.3rc1"
+version = "1.1.3"
 description = "Symbolic and units-aware calculations with LaTeX rendering for Jupyter notebooks, optimized for Quarto PDF documentation."
 readme = "README.md"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "tomlkit>=0.13.3",
 ]
 name = "keecas"
-version = "1.1.2"
+version = "1.1.3rc1"
 description = "Symbolic and units-aware calculations with LaTeX rendering for Jupyter notebooks, optimized for Quarto PDF documentation."
 readme = "README.md"
 

--- a/src/keecas/config/manager.py
+++ b/src/keecas/config/manager.py
@@ -456,7 +456,22 @@ class ConfigManager:
         return config_dir / "config.toml"
 
     def _get_local_config_path(self) -> Path:
-        """Get path to local configuration file."""
+        """Search upward from CWD for .keecas/config.toml, falling back to CWD.
+
+        This allows config to be found when running from a subdirectory of the project.
+        The global config path is excluded to avoid treating it as a local config.
+        """
+        current = Path.cwd()
+        while True:
+            candidate = current / ".keecas" / "config.toml"
+            if candidate == self._global_config_path:
+                break
+            if candidate.exists():
+                return candidate
+            parent = current.parent
+            if parent == current:  # Reached filesystem root
+                break
+            current = parent
         return Path.cwd() / ".keecas" / "config.toml"
 
     def load_configs(self) -> None:
@@ -495,10 +510,13 @@ class ConfigManager:
         config_version = metadata.get("config_version", "0.1.0")
         current_version = get_current_schema_version()
 
-        # Load actual config data - use tomlkit to preserve structure
+        # Load actual config data - use tomlkit to preserve structure for migration,
+        # but convert to native Python types via round-trip to avoid tomlkit wrapper
+        # types (e.g. tomlkit.items.String) being stored in config, which causes
+        # toml.dumps() to iterate strings as character sequences.
         with open(config_path, encoding="utf-8") as f:
             toml_doc = tomlkit.load(f)
-            config_data = dict(toml_doc)  # Convert to dict for migration
+            config_data = toml.loads(tomlkit.dumps(toml_doc))
 
         # Check if migration needed
         if ConfigMigration.needs_migration(config_version, current_version):

--- a/uv.lock
+++ b/uv.lock
@@ -877,7 +877,7 @@ wheels = [
 
 [[package]]
 name = "keecas"
-version = "1.1.2"
+version = "1.1.3rc1"
 source = { editable = "." }
 dependencies = [
     { name = "flatten-dict" },

--- a/uv.lock
+++ b/uv.lock
@@ -877,7 +877,7 @@ wheels = [
 
 [[package]]
 name = "keecas"
-version = "1.1.3rc1"
+version = "1.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "flatten-dict" },


### PR DESCRIPTION
## Summary
- Fix language values serialized as `["e", "s"]` instead of `"es"` in `keecas config show` (tomlkit wrapper type leak)
- Fix local config not discovered when running from a project subdirectory
- Bump version to `1.1.3`

## Changes
See kompre/keecas#86 for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)