### PR TITLE
fix(formatters): fix negative coefficient parenthesization in format_mul

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "tomlkit>=0.13.3",
 ]
 name = "keecas"
-version = "1.1.4"
+version = "1.1.5b1"
 description = "Symbolic and units-aware calculations with LaTeX rendering for Jupyter notebooks, optimized for Quarto PDF documentation."
 readme = "README.md"
 

--- a/src/keecas/formatters.py
+++ b/src/keecas/formatters.py
@@ -354,6 +354,7 @@ def format_mul(value: Mul, col_index: int = 0, **kwargs) -> str:
     Simple cases (transformed):
         - 5*meter -> "5 \\cdot \\mathrm{meter}"
         - 3.14*kilogram -> "3.14 \\cdot \\mathrm{kilogram}"
+        - -5*kN -> "-5 \\cdot \\mathrm{kilonewton}" (sign kept outside, no parens)
 
     Complex cases (NOT transformed, formatted as-is):
         - 5*kN / (3*m) -> displayed as division expression
@@ -377,8 +378,15 @@ def format_mul(value: Mul, col_index: int = 0, **kwargs) -> str:
 
     Notes
     -----
-    Transformation: 5*meter -> UnevaluatedExpr(5) * UnevaluatedExpr(meter)
-    This produces "5 \\cdot \\mathrm{meter}" instead of "5meter" in LaTeX.
+    Transformation uses as_coeff_Mul() to extract the numeric coefficient, then
+    wraps coefficient and unit separately in UnevaluatedExpr to produce clean
+    LaTeX spacing: "5 \\mathrm{meter}" instead of "5meter".
+
+    Negative coefficients have their sign extracted before wrapping to avoid
+    parenthesization: UnevaluatedExpr(-5) would produce "(-5)" in LaTeX, so
+    the sign is stripped and prepended as a literal "-" after formatting.
+
+    For non-numeric leading factors (e.g., pi*meter), falls back to as_two_terms().
 
     For complex expressions with calculations, the function preserves the
     original structure to maintain clarity in mathematical notation.
@@ -403,8 +411,28 @@ def format_mul(value: Mul, col_index: int = 0, **kwargs) -> str:
 
     if not has_symbols and not has_division and not has_addition and not has_multiple_units:
         # Simple "numeric * units" pattern - transform for cleaner display
-        transformed = value | pc.as_two_terms(as_mul=True)
-        return format_sympy(transformed, col_index, **kwargs)
+        from sympy import UnevaluatedExpr
+
+        coeff, unit_part = value.as_coeff_Mul()
+
+        # as_coeff_Mul returns coeff=1 when no pure numeric factor exists
+        # (e.g., pi*meter -> coeff=1, unit_part=pi*meter).
+        # Fall back to as_two_terms for correct splitting in that case.
+        if coeff == 1:
+            transformed = value | pc.as_two_terms(as_mul=True)
+            return format_sympy(transformed, col_index, **kwargs)
+
+        # For negative coefficients, strip the sign and prepend it as a literal "-".
+        # UnevaluatedExpr(-5) produces "(-5)" in LaTeX; this avoids the parentheses.
+        # NOTE: the coeff==1 guard must come BEFORE this block — negating coeff=-1
+        # would make it 1 and incorrectly trigger the fallback.
+        sign_prefix = ""
+        if coeff.is_negative:
+            sign_prefix = "-"
+            coeff = -coeff  # absolute value
+
+        transformed = UnevaluatedExpr(coeff) * UnevaluatedExpr(unit_part)
+        return sign_prefix + format_sympy(transformed, col_index, **kwargs)
 
     # Complex expression - format as-is
     return format_sympy(value, col_index, **kwargs)

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -246,6 +246,18 @@ def test_formatter_mul_complex_expressions():
     # Should not be transformed (no \cdot for simple xy multiplication)
     assert "x" in result_symbolic and "y" in result_symbolic
 
+    # Test 5: Negative numeric * single unit (should NOT produce parenthesized negative)
+    # Bug: "-5 kN" was rendered as "(-5) kN" due to UnevaluatedExpr wrapping
+    neg_expr = S(-5 * u.kN)
+    assert isinstance(neg_expr, Mul)
+    result_neg = format_value(neg_expr)
+    assert isinstance(result_neg, str)
+    assert "5" in result_neg
+    assert "kN" in result_neg or "kilonewton" in result_neg
+    # Must start with "-" directly, not with "(-"
+    assert result_neg.startswith("-"), f"Expected result to start with '-', got: {result_neg}"
+    assert not result_neg.startswith("(-"), f"Unexpected parenthesized negative: {result_neg}"
+
 
 def test_format_decimal_numbers():
     text = "The values are 3.14159, -2.71828, and 0.57721."

--- a/uv.lock
+++ b/uv.lock
@@ -877,7 +877,7 @@ wheels = [
 
 [[package]]
 name = "keecas"
-version = "1.1.4"
+version = "1.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "flatten-dict" },

--- a/uv.lock
+++ b/uv.lock
@@ -877,7 +877,7 @@ wheels = [
 
 [[package]]
 name = "keecas"
-version = "1.1.5"
+version = "1.1.5b1"
 source = { editable = "." }
 dependencies = [
     { name = "flatten-dict" },


### PR DESCRIPTION
## Summary

- Fixes `(-5) kN` rendering for negative single-unit quantities — should display as `-5 kN`
- Replaces the two-branch `as_two_terms()` approach with a unified path using `as_coeff_Mul()`, which is semantically correct for extracting a numeric coefficient
- A `coeff == 1` guard (placed before sign-stripping) handles non-numeric leading factors like `pi*meter` via the existing `as_two_terms` fallback
- Bumps version to `1.1.5b1`

## Changes

- `src/keecas/formatters.py`: refactored `format_mul` simple-case block; updated docstring Notes section
- `tests/test_display.py`: added Test 5 asserting negative single-unit quantities start with `-` not `(-`
- `pyproject.toml` / `uv.lock`: version `1.1.5b1`

## Test plan

- [ ] `uv run pytest tests/test_display.py::test_formatter_mul_complex_expressions -v` passes
- [ ] `uv run pytest tests/ --tb=short` passes (240/241, pre-existing unrelated failure excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)