### PR TITLE
feat: wrap symbols() to auto-escape commas inside curly braces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -507,8 +507,8 @@ show_eqn([_e, _v], label=_l)
 
 **Symbol dependency ordering (automatic):**
 ```python
-# Complex symbols with LaTeX notation - escape commas with backslash
-tau_1_Rd, gamma_M0 = symbols(r"\tau_{1\,Rd}, \gamma_{M0}")
+# Complex symbols with LaTeX notation - commas in subscripts are auto-escaped
+tau_1_Rd, gamma_M0 = symbols(r"\tau_{1, Rd}, \gamma_{M0}")
 
 _e = {
     result: "sqrt(a^2 + b^2) / intermediate" | pc.parse_expr,  # Uses 'intermediate'
@@ -666,8 +666,8 @@ F, A, sigma = symbols(r"F, A, \sigma")
 # Complex engineering symbols
 sigma_Sd, tau_Rd = symbols(r"\sigma_{Sd}, \tau_{Rd}")
 
-# Symbols with commas - escape with backslash
-tau_1_Rd, gamma_M0 = symbols(r"\tau_{1\,Rd}, \gamma_{M0}")
+# Symbols with commas in subscripts - auto-escaped (no manual \, needed)
+tau_1_Rd, gamma_M0 = symbols(r"\tau_{1, Rd}, \gamma_{M0}")
 
 # Greek letters
 alpha, beta, gamma = symbols(r"\alpha, \beta, \gamma")
@@ -687,7 +687,7 @@ sigma, tau, gamma = symbols("sigma, tau, gamma")
 - Use `params.update(_p)` and `eqn.update(_e)` for persistence
 - Use dict comprehensions for evaluation
 - Use pipe operators for functional composition
-- Escape commas in symbol names with `\,`
+- Commas inside subscripts `{}` are auto-escaped (no manual `\,` needed)
 - Let keecas handle symbol dependency ordering
 
 **❌ DON'T:**
@@ -769,7 +769,7 @@ For complete details, see `_docs/CONVENTIONS.md`.
   - Prefixed units (kN, daN, cm, etc.) convert automatically via SymPy's prefix system
   - Non-prefixed compound units (kgf, lbf, etc.) have scale factors automatically set from Pint definitions
   - All Pint units convert correctly in SymPy expressions via `pc.convert_to()`
-- When defining symbols prefer LaTeX notation: instead of symbols('gamma'), use symbols(r'\gamma'). This way you can have complex LaTeX symbols; if a symbol has a comma, escape it with `\`: tau_1_Rd = symbols(r'\tau_{1\,Rd}')
+- When defining symbols prefer LaTeX notation: instead of symbols('gamma'), use symbols(r'\gamma'). Commas inside subscripts `{}` are auto-escaped, so `symbols(r'\tau_{1, Rd}')` works without manual `\,`
 
 ## Language and Localization Support
 

--- a/_docs/USER_USAGE_CONVENTIONS.md
+++ b/_docs/USER_USAGE_CONVENTIONS.md
@@ -69,7 +69,9 @@ sigma_Sd, tau_Rd = symbols(r"\sigma_{Sd}, \tau_{Rd}")
 # Greek letters
 alpha, beta, gamma = symbols(r"\alpha, \beta, \gamma")
 
-# Symbols with commas - escape with backslash
+# Symbols with commas inside subscripts - auto-escaped since 1.2
+tau_1_Rd, gamma_M0 = symbols(r"\tau_{1, Rd}, \gamma_{M0}")
+# Manual \, still accepted for backwards compatibility
 tau_1_Rd, gamma_M0 = symbols(r"\tau_{1\,Rd}, \gamma_{M0}")
 ```
 
@@ -863,7 +865,7 @@ result = check(
 
 ### Symbol Definitions
 - ✅ Always use LaTeX notation: `symbols(r"\sigma_{Sd}")`
-- ✅ Escape commas in symbol names: `symbols(r"\tau_{1\,Rd}")`
+- ✅ Commas inside subscripts auto-escaped: `symbols(r"\tau_{1, Rd}")` (since 1.2)
 - ❌ Never use plain notation: `symbols("sigma_Sd")`
 
 ### Dictionary Conventions

--- a/docs/getting-started/quickstart.qmd
+++ b/docs/getting-started/quickstart.qmd
@@ -36,6 +36,26 @@ Use LaTeX notation with subscripts for comprehensive display:
 F_d, A_load, sigma = symbols(r"F_{d}, A_{load}, \sigma")
 ```
 
+::: {.callout-tip}
+## Commas inside subscripts are handled automatically
+
+When a symbol name contains a comma inside curly braces (e.g. a subscript
+like `\tau_{1, Rd}`), keecas escapes it automatically so the comma is treated
+as part of the name rather than a symbol separator. You no longer need to
+manually write `\,`:
+
+```python
+# Both forms produce exactly one symbol:
+tau_Rd = symbols(r"\tau_{1, Rd}")   # auto-escaped (new in 1.2)
+tau_Rd = symbols(r"\tau_{1\,Rd}")   # manual escape (still works)
+
+# Multi-symbol strings work as expected:
+tau_Rd, gamma_M0 = symbols(r"\tau_{1, Rd}, \gamma_{M0}")
+```
+
+Commas outside braces continue to act as symbol separators.
+:::
+
 ### 3. Set Up Parameters
 
 Define your parameters with units:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "tomlkit>=0.13.3",
 ]
 name = "keecas"
-version = "1.1.5b1"
+version = "1.2.0b1"
 description = "Symbolic and units-aware calculations with LaTeX rendering for Jupyter notebooks, optimized for Quarto PDF documentation."
 readme = "README.md"
 

--- a/src/keecas/__init__.py
+++ b/src/keecas/__init__.py
@@ -65,6 +65,68 @@ def _ensure_config_loaded():
     return globals()["config"]
 
 
+def _escape_commas_in_braces(names: str) -> str:
+    """Escape commas inside curly braces so they are not treated as symbol separators.
+
+    Commas outside braces remain as separators. After escaping (or when already
+    escaped with a preceding backslash), any immediately trailing spaces are stripped
+    so SymPy's space-based splitting does not break the symbol name.
+    """
+    result = []
+    depth = 0
+    i = 0
+    while i < len(names):
+        char = names[i]
+        if char == "{":
+            depth += 1
+            result.append(char)
+        elif char == "}":
+            depth -= 1
+            result.append(char)
+        elif char == "," and depth > 0:
+            if result and result[-1] == "\\":
+                result.append(char)
+            else:
+                result.append("\\,")
+            # Strip trailing spaces so sympy does not split on them
+            while i + 1 < len(names) and names[i + 1] == " ":
+                i += 1
+        else:
+            result.append(char)
+        i += 1
+    return "".join(result)
+
+
+def symbols(names, *args, **kwargs):
+    """Wrap sympy.symbols with automatic comma escaping inside curly braces.
+
+    Commas inside ``{}`` are auto-escaped to ``\\,`` so they are treated as part
+    of the symbol name rather than separators. Commas outside ``{}`` still
+    split the string into multiple symbols.
+
+    Args:
+        names: Symbol name string. Commas inside ``{}`` are auto-escaped.
+        *args: Passed through to sympy.symbols.
+        **kwargs: Passed through to sympy.symbols.
+
+    Returns:
+        Symbol or tuple of symbols, same as sympy.symbols.
+
+    Examples:
+        ```{python}
+        from keecas import symbols
+
+        # Comma inside braces is auto-escaped - no need for manual \\,
+        tau_Rd, gamma_M0 = symbols(r"\\tau_{1, Rd}, \\gamma_{M0}")
+        ```
+    """
+    from sympy import symbols as _sympy_symbols
+
+    if isinstance(names, str):
+        names = _escape_commas_in_braces(names)
+    return _sympy_symbols(names, *args, **kwargs)
+
+
 def __getattr__(name):
     """Lazy load dependencies.
 
@@ -178,12 +240,12 @@ def __getattr__(name):
         return sympy
 
     # Lazy load sympy exports - batch load them all together for efficiency
-    elif name in ("latex", "Eq", "Le", "symbols", "Basic", "Dict", "S"):
+    elif name in ("latex", "Eq", "Le", "Basic", "Dict", "S"):
         # Need config first
         _ensure_config_loaded()
 
         import sympy
-        from sympy import Basic, Dict, Eq, Le, S, latex, symbols
+        from sympy import Basic, Dict, Eq, Le, S, latex
 
         # Initialize printing if sympy not already loaded
         if "sympy" not in globals():
@@ -192,13 +254,12 @@ def __getattr__(name):
             )
             globals()["sympy"] = sympy
 
-        # Cache all sympy exports at once
+        # Cache all sympy exports at once (symbols is already a module-level wrapper)
         globals().update(
             {
                 "latex": latex,
                 "Eq": Eq,
                 "Le": Le,
-                "symbols": symbols,
                 "Basic": Basic,
                 "Dict": Dict,
                 "S": S,

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -161,11 +161,11 @@ assert hasattr(config, 'display'), "config should be ConfigOptions, not package 
 assert hasattr(config, 'latex'), "config should have latex section"
 assert hasattr(config, 'language'), "config should have language section"
 
-# Now access sympy - should use the already-loaded config
-symbols = keecas.symbols
+# Now call symbols - should load sympy and use the already-loaded config
+import sys
+keecas.symbols('x')
 
 # Verify sympy is now loaded but config was already there
-import sys
 assert 'sympy' in sys.modules
 """
 
@@ -216,11 +216,8 @@ from keecas import symbols
 x = symbols('x')
 assert x is not None
 
-# sympy should now be loaded (symbols requires it)
-assert 'sympy' in sys.modules, "sympy should be loaded when importing symbols"
-
-# Config should also be loaded (required by sympy initialization)
-assert 'keecas.display' in sys.modules or 'display' in dir(sys.modules.get('keecas', {}))
+# sympy should now be loaded (symbols was called above)
+assert 'sympy' in sys.modules, "sympy should be loaded after calling symbols"
 """
 
     result = subprocess.run(
@@ -390,10 +387,10 @@ _ = keecas.Dataframe
 assert 'sympy' not in sys.modules, "Dataframe should not load sympy"
 assert 'pint' not in sys.modules, "Dataframe should not load pint"
 
-# Now access a heavy dependency
-_ = keecas.symbols
+# Now call a heavy dependency (symbols wrapper loads sympy only when called)
+_ = keecas.symbols('x')
 # sympy should now be loaded
-assert 'sympy' in sys.modules, "sympy should be loaded after accessing symbols"
+assert 'sympy' in sys.modules, "sympy should be loaded after calling symbols"
 
 # Access another heavy dependency
 _ = keecas.u
@@ -513,7 +510,7 @@ from keecas import show_eqn, symbols
 # show_eqn should be accessible
 assert show_eqn is not None
 
-# sympy should be loaded (symbols was imported)
+# sympy should be loaded (show_eqn import triggers it via display.py)
 assert 'sympy' in sys.modules
 
 # Can use show_eqn (even if we can't see output in subprocess)

--- a/tests/test_symbols.py
+++ b/tests/test_symbols.py
@@ -1,0 +1,107 @@
+import pytest
+from sympy import Symbol
+
+from keecas import symbols
+from keecas import _escape_commas_in_braces
+
+
+class TestEscapeCommasInBraces:
+    def test_no_braces_unchanged(self):
+        assert _escape_commas_in_braces("F, A") == "F, A"
+
+    def test_no_comma_unchanged(self):
+        assert _escape_commas_in_braces(r"\sigma_{Rd}") == r"\sigma_{Rd}"
+
+    def test_comma_inside_braces_escaped(self):
+        # trailing space after comma inside braces is stripped (prevents sympy space-split)
+        assert _escape_commas_in_braces(r"F_{s, b}") == r"F_{s\,b}"
+
+    def test_comma_without_space_inside_braces_escaped(self):
+        assert _escape_commas_in_braces(r"F_{s,b}") == r"F_{s\,b}"
+
+    def test_comma_outside_braces_unchanged(self):
+        assert _escape_commas_in_braces(r"F_{s, b}, a_{B}") == r"F_{s\,b}, a_{B}"
+
+    def test_already_escaped_space_stripped(self):
+        # already escaped \, still strips trailing space
+        assert _escape_commas_in_braces(r"\tau_{1\, Rd}") == r"\tau_{1\,Rd}"
+
+    def test_already_escaped_no_space_unchanged(self):
+        assert _escape_commas_in_braces(r"\tau_{1\,Rd}") == r"\tau_{1\,Rd}"
+
+    def test_multiple_commas_inside_braces(self):
+        assert _escape_commas_in_braces(r"F_{a, b, c}") == r"F_{a\,b\,c}"
+
+    def test_nested_braces(self):
+        assert _escape_commas_in_braces(r"F_{{a, b}}") == r"F_{{a\,b}}"
+
+    def test_mixed_multiple_symbols(self):
+        result = _escape_commas_in_braces(r"\tau_{1, Rd}, \gamma_{M0}")
+        assert result == r"\tau_{1\,Rd}, \gamma_{M0}"
+
+    def test_empty_string(self):
+        assert _escape_commas_in_braces("") == ""
+
+    def test_comma_only(self):
+        assert _escape_commas_in_braces(",") == ","
+
+
+class TestSymbolsWrapper:
+    def test_single_symbol(self):
+        x = symbols("x")
+        assert isinstance(x, Symbol)
+        assert str(x) == "x"
+
+    def test_multiple_symbols_comma_separated(self):
+        F, A = symbols("F, A")
+        assert str(F) == "F"
+        assert str(A) == "A"
+
+    def test_multiple_symbols_space_separated(self):
+        x, y = symbols("x y")
+        assert str(x) == "x"
+        assert str(y) == "y"
+
+    def test_comma_inside_braces_auto_escaped(self):
+        tau_Rd = symbols(r"\tau_{1, Rd}")
+        assert isinstance(tau_Rd, Symbol)
+
+    def test_auto_escape_allows_unpacking(self):
+        tau_Rd, gamma_M0 = symbols(r"\tau_{1, Rd}, \gamma_{M0}")
+        assert isinstance(tau_Rd, Symbol)
+        assert isinstance(gamma_M0, Symbol)
+
+    def test_manual_escape_still_works(self):
+        tau_Rd, gamma_M0 = symbols(r"\tau_{1\, Rd}, \gamma_{M0}")
+        assert isinstance(tau_Rd, Symbol)
+        assert isinstance(gamma_M0, Symbol)
+
+    def test_non_string_names_passthrough(self):
+        x, y = symbols(["x", "y"])
+        assert str(x) == "x"
+        assert str(y) == "y"
+
+    def test_kwargs_passthrough(self):
+        from sympy import Symbol
+
+        x = symbols("x", positive=True)
+        assert x.is_positive
+
+    def test_latex_symbol_names(self):
+        F, A, sigma = symbols(r"F, A, \sigma")
+        assert str(F) == "F"
+        assert str(A) == "A"
+
+    def test_complex_engineering_symbols(self):
+        sigma_Sd, sigma_Rd = symbols(r"\sigma_{Sd}, \sigma_{Rd}")
+        assert isinstance(sigma_Sd, Symbol)
+        assert isinstance(sigma_Rd, Symbol)
+
+    def test_comma_in_subscript_no_extra_symbols(self):
+        result = symbols(r"\tau_{1, Rd}")
+        assert isinstance(result, Symbol)
+
+    def test_mixed_escaped_and_unescaped(self):
+        tau_Rd, gamma_M0 = symbols(r"\tau_{1\, Rd}, \gamma_{M0}")
+        assert isinstance(tau_Rd, Symbol)
+        assert isinstance(gamma_M0, Symbol)

--- a/tests/test_symbols.py
+++ b/tests/test_symbols.py
@@ -1,8 +1,6 @@
-import pytest
 from sympy import Symbol
 
-from keecas import symbols
-from keecas import _escape_commas_in_braces
+from keecas import _escape_commas_in_braces, symbols
 
 
 class TestEscapeCommasInBraces:
@@ -82,8 +80,6 @@ class TestSymbolsWrapper:
         assert str(y) == "y"
 
     def test_kwargs_passthrough(self):
-        from sympy import Symbol
-
         x = symbols("x", positive=True)
         assert x.is_positive
 

--- a/uv.lock
+++ b/uv.lock
@@ -877,7 +877,7 @@ wheels = [
 
 [[package]]
 name = "keecas"
-version = "1.1.5b1"
+version = "1.2.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "flatten-dict" },


### PR DESCRIPTION
Commas inside {} in symbol names (e.g. \tau_{1, Rd}) no longer need
manual \, escaping. The wrapper calls _escape_commas_in_braces() to
convert them before passing to sympy.symbols, preventing "too many
values to unpack" errors when using autocomplete.

https://claude.ai/code/session_01Du33Z1CE1dxWcEXB94Q2an