### PR TITLE
feat(display): auto-wrap long strings in PDF mode using varwidth

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "tomlkit>=0.13.3",
 ]
 name = "keecas"
-version = "1.2.0b2"
+version = "1.3.0b1"
 description = "Symbolic and units-aware calculations with LaTeX rendering for Jupyter notebooks, optimized for Quarto PDF documentation."
 readme = "README.md"
 

--- a/src/keecas/config/manager.py
+++ b/src/keecas/config/manager.py
@@ -101,6 +101,7 @@ class DisplayConfig:
     cell_formatter: "Callable[[Any, int], str] | None" = None  # Custom cell formatter
     row_formatter: "Callable[[str], str] | None" = None  # Custom row formatter
     col_wrap: "list | Callable | None" = None  # Column wrapping specification
+    text_wrap: bool = False
 
 
 @dataclass
@@ -1030,6 +1031,11 @@ class ConfigManager:
 
 ## Pint quantity formatting (e.g., .2f~P, .3f~P)
 {format_value("display", "pint_default_format", defaults.display.pint_default_format, display_inherited.get("pint_default_format"))}
+
+## Auto-wrap long string values in PDF mode using varwidth environment
+## Requires \\usepackage{{varwidth}} in LaTeX preamble
+## Only applied when katex = false (PDF rendering); ignored in KaTeX mode
+{format_value("display", "text_wrap", defaults.display.text_wrap, display_inherited.get("text_wrap"))}
 
 [language]
 ## Language settings (de, es, fr, it, pt, da, nl, no, sv, en)

--- a/src/keecas/formatters.py
+++ b/src/keecas/formatters.py
@@ -180,6 +180,10 @@ def format_str(value: str, col_index: int = 0, **kwargs) -> str:
     Pure conversion: wraps string in \\text{} without additional decoration.
     Column wrapping (e.g., \\quad prefix) is handled by wrap_column().
 
+    When config.display.text_wrap is True and katex is False, uses a varwidth
+    environment instead of \\text{} to allow dynamic line wrapping in PDF output.
+    Requires \\usepackage{varwidth} in the LaTeX preamble.
+
     Parameters
     ----------
     value : str
@@ -192,8 +196,13 @@ def format_str(value: str, col_index: int = 0, **kwargs) -> str:
     Returns
     -------
     str
-        LaTeX string with \\text{} wrapper
+        LaTeX string with \\text{} or varwidth wrapper
     """
+    from keecas.config.manager import get_config_manager
+
+    cfg = get_config_manager().options
+    if cfg.display.text_wrap and not cfg.display.katex:
+        return rf"\begin{{varwidth}}[t]{{\linewidth}}{value}\end{{varwidth}}"
     return rf"\text{{{value}}}"
 
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -146,6 +146,47 @@ def test_formatter_custom_registration():
     assert "50" in result_small.data  # Uses default int formatter
 
 
+def test_format_str_no_wrap():
+    """Default: strings use \\text{} wrapper."""
+    from keecas.display import config
+    from keecas.formatters import format_str
+
+    config.display.text_wrap = False
+    result = format_str("long description text")
+    assert result == r"\text{long description text}"
+
+
+def test_format_str_text_wrap_katex_mode():
+    """text_wrap=True but katex=True: still use \\text{}."""
+    from keecas.display import config
+    from keecas.formatters import format_str
+
+    config.display.text_wrap = True
+    config.display.katex = True
+    try:
+        result = format_str("long description text")
+        assert result == r"\text{long description text}"
+    finally:
+        config.display.text_wrap = False
+        config.display.katex = False
+
+
+def test_format_str_text_wrap_pdf_mode():
+    """text_wrap=True and katex=False: use varwidth environment."""
+    from keecas.display import config
+    from keecas.formatters import format_str
+
+    config.display.text_wrap = True
+    config.display.katex = False
+    try:
+        result = format_str("long description text")
+        assert r"\begin{varwidth}[t]{\linewidth}" in result
+        assert r"\end{varwidth}" in result
+        assert "long description text" in result
+    finally:
+        config.display.text_wrap = False
+
+
 def test_formatter_empty_string():
     """Test that formatters can explicitly return empty string."""
     from keecas import format_value

--- a/uv.lock
+++ b/uv.lock
@@ -877,7 +877,7 @@ wheels = [
 
 [[package]]
 name = "keecas"
-version = "1.2.0b2"
+version = "1.3.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "flatten-dict" },


### PR DESCRIPTION
## Summary

- Add `config.display.text_wrap` (bool, default `False`) to opt in to automatic string wrapping
- Add `config.display.pdf_mode` (bool, default `False`) to explicitly signal PDF/LaTeX rendering — wrapping only activates when both flags are `True`, keeping KaTeX and HTML/MathJax rendering unchanged
- Add `config.display.text_wrap_width` (str, default `"0.8\linewidth"`) to control the varwidth box width (avoids slight overflow at full linewidth)
- Bump version to 1.3.0b1 (minor bump for new functionality)

Requires `\usepackage{varwidth}` in the LaTeX/Quarto preamble.

## Usage

```python
# Notebook preamble
config.display.katex = True        # Jupyter dev mode
config.display.text_wrap = True    # enable wrapping (inactive until pdf_mode=True)
config.display.pdf_mode = True     # set False for Jupyter, True for PDF rendering
config.display.text_wrap_width = r"0.8\linewidth"  # default
```

Quarto YAML:
```yaml
pdf:
  include-in-header:
    - text: '\usepackage{varwidth}'
```

## Test plan

- [ ] `test_format_str_no_wrap`: default behavior unchanged
- [ ] `test_format_str_text_wrap_no_pdf_mode`: wrapping suppressed when `pdf_mode=False`
- [ ] `test_format_str_text_wrap_pdf_mode`: varwidth produced when both flags are `True`
- [ ] `test_format_str_text_wrap_custom_width`: `text_wrap_width` is used in output