### PR TITLE
feat(display): auto-wrap long strings in PDF mode using varwidth

### DIFF
--- a/examples/quarto_example/quarto_example.ipynb
+++ b/examples/quarto_example/quarto_example.ipynb
@@ -5,31 +5,7 @@
    "id": "cell-0",
    "metadata": {},
    "source": [
-    "---\n",
-    "title: Keecas Quarto Example\n",
-    "toc: true\n",
-    "format:\n",
-    "    html:\n",
-    "        include-in-header:\n",
-    "            # this is needed for equation numbering and labeling in HTML output             \n",
-    "            - text: | \n",
-    "                <script>\n",
-    "                MathJax = { tex: { tags: 'ams' } };\n",
-    "                </script>\n",
-    "            # this get rid of unnecessary vertical scrollbars (may need to be adjusted)\n",
-    "            - text: |\n",
-    "                <style>\n",
-    "                .math.display {\n",
-    "                  max-width: 100%;\n",
-    "                  padding-right: 3em;\n",
-    "                }\n",
-    "                </style>\n",
-    "    pdf:\n",
-    "        echo: false\n",
-    "        classoption: [fleqn] # personal preference\n",
-    "echo: true\n",
-    "keep-tex: true\n",
-    "---"
+    "---\ntitle: Keecas Quarto Example\ntoc: true\nformat:\n    html:\n        include-in-header:\n            # this is needed for equation numbering and labeling in HTML output             \n            - text: | \n                <script>\n                MathJax = { tex: { tags: 'ams' } };\n                </script>\n            # this get rid of unnecessary vertical scrollbars (may need to be adjusted)\n            - text: |\n                <style>\n                .math.display {\n                  max-width: 100%;\n                  padding-right: 3em;\n                }\n                </style>\n    pdf:\n        echo: false\n        classoption: [fleqn] # personal preference\n        include-in-header:\n            - text: '\\\\usepackage{varwidth}'\necho: true\nkeep-tex: true\n---"
    ]
   },
   {
@@ -1682,6 +1658,21 @@
     "\n",
     ":::"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "text-wrap-md",
+   "metadata": {},
+   "source": "## Text Wrapping for Long String Descriptions\n\nString values passed to `show_eqn` are normally wrapped in `\\\\text{}`, which creates an unbreakable box that can overflow the line in PDF output when descriptions are long. Enabling `text_wrap` uses a `varwidth` environment instead, so descriptions reflow dynamically to fit the available space.\n\n::: {.callout-note}\n\n**PDF setup:** add `\\\\usepackage{varwidth}` to the LaTeX preamble (already included in this notebook's YAML frontmatter). Set `config.display.pdf_mode = True` when rendering to PDF; keep it `False` in Jupyter dev mode (KaTeX does not support `varwidth`).\n\n:::",
+   "attachments": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "text-wrap-example",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Symbols for material properties\nE_s, f_yk, gamma_M0 = symbols(r\"E_s, f_{yk}, \\\\gamma_{M0}\")\n\n_p = {\n    E_s:      210 * u.GPa,\n    f_yk:     355 * u.MPa,\n    gamma_M0: 1.0,\n}\n\n# Descriptions long enough to overflow a PDF line without wrapping\n_d = {\n    E_s:      \"elastic modulus of structural steel (EN 1993-1-1, clause 3.2.6)\",\n    f_yk:     \"characteristic yield strength for steel grade S355, plate thickness t <= 40 mm\",\n    gamma_M0: \"partial factor for resistance of cross-sections (EN 1993-1-1, table 6.1)\",\n}\n\n# Enable PDF text wrapping for this section.\n# pdf_mode=True activates varwidth; keep False in the dev-mode cell above for KaTeX.\nconfig.display.text_wrap = True\nconfig.display.pdf_mode = True\n\nshow_eqn([_p, _d])\n\nconfig.display.pdf_mode = False  # reset: subsequent cells use KaTeX-safe \\\\text{}"
   },
   {
    "cell_type": "markdown",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "tomlkit>=0.13.3",
 ]
 name = "keecas"
-version = "1.3.0b1"
+version = "1.3.0b2"
 description = "Symbolic and units-aware calculations with LaTeX rendering for Jupyter notebooks, optimized for Quarto PDF documentation."
 readme = "README.md"
 

--- a/src/keecas/config/manager.py
+++ b/src/keecas/config/manager.py
@@ -102,6 +102,8 @@ class DisplayConfig:
     row_formatter: "Callable[[str], str] | None" = None  # Custom row formatter
     col_wrap: "list | Callable | None" = None  # Column wrapping specification
     text_wrap: bool = False
+    pdf_mode: bool = False
+    text_wrap_width: str = r"0.8\linewidth"
 
 
 @dataclass
@@ -1032,10 +1034,17 @@ class ConfigManager:
 ## Pint quantity formatting (e.g., .2f~P, .3f~P)
 {format_value("display", "pint_default_format", defaults.display.pint_default_format, display_inherited.get("pint_default_format"))}
 
+## PDF rendering mode - enables varwidth text wrapping for string values
+## Set to true when rendering to PDF/LaTeX; keeps KaTeX and HTML rendering unchanged
+{format_value("display", "pdf_mode", defaults.display.pdf_mode, display_inherited.get("pdf_mode"))}
+
 ## Auto-wrap long string values in PDF mode using varwidth environment
 ## Requires \\usepackage{{varwidth}} in LaTeX preamble
-## Only applied when katex = false (PDF rendering); ignored in KaTeX mode
+## Only applied when both text_wrap = true and pdf_mode = true
 {format_value("display", "text_wrap", defaults.display.text_wrap, display_inherited.get("text_wrap"))}
+
+## Width for varwidth text wrapping (any LaTeX dimension, e.g. 0.8\\linewidth, 10cm)
+{format_value("display", "text_wrap_width", defaults.display.text_wrap_width, display_inherited.get("text_wrap_width"))}
 
 [language]
 ## Language settings (de, es, fr, it, pt, da, nl, no, sv, en)

--- a/src/keecas/formatters.py
+++ b/src/keecas/formatters.py
@@ -201,8 +201,9 @@ def format_str(value: str, col_index: int = 0, **kwargs) -> str:
     from keecas.config.manager import get_config_manager
 
     cfg = get_config_manager().options
-    if cfg.display.text_wrap and not cfg.display.katex:
-        return rf"\begin{{varwidth}}[t]{{\linewidth}}{value}\end{{varwidth}}"
+    if cfg.display.text_wrap and cfg.display.pdf_mode:
+        width = cfg.display.text_wrap_width
+        return rf"\begin{{varwidth}}[t]{{{width}}}{value}\end{{varwidth}}"
     return rf"\text{{{value}}}"
 
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -156,35 +156,52 @@ def test_format_str_no_wrap():
     assert result == r"\text{long description text}"
 
 
-def test_format_str_text_wrap_katex_mode():
-    """text_wrap=True but katex=True: still use \\text{}."""
+def test_format_str_text_wrap_no_pdf_mode():
+    """text_wrap=True but pdf_mode=False: still use \\text{}."""
     from keecas.display import config
     from keecas.formatters import format_str
 
     config.display.text_wrap = True
-    config.display.katex = True
+    config.display.pdf_mode = False
     try:
         result = format_str("long description text")
         assert result == r"\text{long description text}"
     finally:
         config.display.text_wrap = False
-        config.display.katex = False
 
 
 def test_format_str_text_wrap_pdf_mode():
-    """text_wrap=True and katex=False: use varwidth environment."""
+    """text_wrap=True and pdf_mode=True: use varwidth environment."""
     from keecas.display import config
     from keecas.formatters import format_str
 
     config.display.text_wrap = True
-    config.display.katex = False
+    config.display.pdf_mode = True
     try:
         result = format_str("long description text")
-        assert r"\begin{varwidth}[t]{\linewidth}" in result
+        assert r"\begin{varwidth}[t]{" in result
         assert r"\end{varwidth}" in result
         assert "long description text" in result
     finally:
         config.display.text_wrap = False
+        config.display.pdf_mode = False
+
+
+def test_format_str_text_wrap_custom_width():
+    """text_wrap_width config is used in varwidth output."""
+    from keecas.display import config
+    from keecas.formatters import format_str
+
+    config.display.text_wrap = True
+    config.display.pdf_mode = True
+    config.display.text_wrap_width = r"0.5\linewidth"
+    try:
+        result = format_str("long description text")
+        assert r"0.5\linewidth" in result
+    finally:
+        config.display.text_wrap = False
+        config.display.pdf_mode = False
+        config.display.text_wrap_width = r"0.8\linewidth"
 
 
 def test_formatter_empty_string():

--- a/uv.lock
+++ b/uv.lock
@@ -877,7 +877,7 @@ wheels = [
 
 [[package]]
 name = "keecas"
-version = "1.3.0b1"
+version = "1.3.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "flatten-dict" },


### PR DESCRIPTION
## Summary

- Add `config.display.text_wrap` (bool, default `False`) to opt in to automatic string wrapping
- Add `config.display.pdf_mode` (bool, default `False`) to explicitly signal PDF/LaTeX rendering — wrapping only activates when both flags are `True`, keeping KaTeX and HTML/MathJax rendering unchanged
- Add `config.display.text_wrap_width` (str, default `"0.8\linewidth"`) to control the varwidth box width
- Add text wrapping example to `quarto_example.ipynb` with Eurocode material property descriptions
- Bump version to 1.3.0b1 (minor bump for new functionality)

Requires `\usepackage{varwidth}` in the LaTeX/Quarto preamble (already added to the example notebook's YAML frontmatter).

## Usage

```python
# Notebook preamble
config.display.text_wrap = True           # enable wrapping
config.display.pdf_mode = True            # activate for PDF rendering
config.display.text_wrap_width = r"0.8\linewidth"  # default
```

Dev-mode cell (`# | eval: false`):
```python
config.display.pdf_mode = False  # keep False in Jupyter/KaTeX
```

Quarto YAML:
```yaml
pdf:
  include-in-header:
    - text: '\usepackage{varwidth}'
```

## Test plan

- [ ] `test_format_str_no_wrap`: default behavior unchanged
- [ ] `test_format_str_text_wrap_no_pdf_mode`: wrapping suppressed when `pdf_mode=False`
- [ ] `test_format_str_text_wrap_pdf_mode`: varwidth produced when both flags are `True`
- [ ] `test_format_str_text_wrap_custom_width`: `text_wrap_width` is reflected in output