### PR TITLE
ci: re-enable publish-pypi after successful rollout test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,7 @@ jobs:
   publish-pypi:
     name: Publish to PyPI
     needs: release-please
-    # TEMPORARY: disabled for the first guarded rollout run (see verification
-    # plan). Re-enable by restoring the condition below once the
-    # release-please PR/tag/changelog have been confirmed working.
-    # if: needs.release-please.outputs.release_created == 'true'
-    if: false
+    if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write  # attach build artifacts to the GitHub Release


### PR DESCRIPTION
Follow-up to #96. release-please's first run (PR #97) confirmed the pipeline works end-to-end — test.yml ran on the release PR (proving RELEASE_PLEASE_TOKEN works), the changelog/version bump were correct, and lint-fix.yml stayed off the release-please branch.

This removes the temporary `if: false` gate on `publish-pypi` so the next merged release PR actually publishes to PyPI.

Opened directly against `main` since this is a minimal CI-only fix scoped to unblocking the release pipeline itself (mirrors #96, which also had to target `main` directly since release-please only runs on pushes there).