### PR TITLE
ci: drop TestPyPI/dev publish path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
 
 # Prevent concurrent releases
 concurrency:
@@ -10,11 +10,10 @@ concurrency:
   cancel-in-progress: false  # Queue releases instead of canceling
 
 jobs:
-  # main: release-please maintains a standing release PR computed from
-  # conventional commits. Merging that PR creates the tag + GitHub Release.
+  # release-please maintains a standing release PR computed from conventional
+  # commits. Merging that PR creates the tag + GitHub Release.
   release-please:
     name: Release Please
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -75,65 +74,3 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload "${{ needs.release-please.outputs.tag_name }}" dist/* --repo "${{ github.repository }}"
-
-  # dev: every push builds a disposable dev-versioned artifact and publishes
-  # it to TestPyPI. The version is synthesized at build time only and is
-  # never committed back to the branch.
-  publish-testpypi:
-    name: Publish dev build to TestPyPI
-    if: github.ref == 'refs/heads/dev'
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write  # OIDC for TestPyPI Trusted Publishing
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version-file: ".python-version"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-        with:
-          version: "latest"
-          enable-cache: true
-
-      - name: Install dependencies
-        run: uv sync --group dev
-
-      - name: Synthesize disposable dev version
-        run: |
-          uv run python -c "
-          import tomlkit
-          from packaging.version import Version
-
-          path = 'pyproject.toml'
-          with open(path) as f:
-              doc = tomlkit.load(f)
-
-          base_version = Version(doc['project']['version']).base_version
-          dev_version = f'{base_version}.dev${{ github.run_number }}'
-          doc['project']['version'] = dev_version
-
-          with open(path, 'w') as f:
-              tomlkit.dump(doc, f)
-
-          print(f'Synthesized version: {dev_version}')
-          "
-
-      - name: Build package
-        run: |
-          uv build
-          echo "Build artifacts:"
-          ls -lh dist/
-
-      - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
-          print-hash: true
-          verbose: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,48 +150,22 @@ uv sync
 
 ### Branch Protection
 - **main**: Protected, requires PR + passing tests via GitHub Actions
-- **dev**: Unprotected, allows rapid iteration
+- **dev**: Unprotected, integration branch for staging feature work
 - **Feature branches**: Branch from dev, merge back to dev for collaboration
 - **Release flow**: dev → main (via PR) → automated release
 
 ### Release Process
 
-**Publish target is determined automatically by branch + version string** (no PR labels needed):
-- `dev` branch + pre-release version (`a`/`b`/`rc`/`.dev` suffix) → TestPyPI
-- `main` branch + stable version → Production PyPI + git tag + GitHub Release
+**Fully automated via [release-please](https://github.com/googleapis/release-please) — no manual version bumps, ever.**
 
-**Test release to TestPyPI** (from dev):
+1. Merge feature work into `dev` as normal, via PRs from feature branches.
+2. When ready to ship, open a PR from `dev` to `main` and merge it.
+3. On every push to `main`, release-please scans conventional commits (`feat:`, `fix:`, `BREAKING CHANGE`) since the last release tag and maintains a standing PR titled `chore(main): release X.Y.Z` with the computed version bump and an auto-generated `CHANGELOG.md`. The version number is derived entirely from commit history — never from whatever string happens to be sitting in `pyproject.toml`.
+4. Merging that release PR creates the git tag + GitHub Release, which triggers `publish-pypi` to build the package and publish it to PyPI via OIDC Trusted Publishing (no API tokens).
 
-1. **Bump version** to a pre-release on dev:
-   ```bash
-   git checkout dev
-   uv version --bump patch  # then manually append b1, e.g. 1.1.2b1
-   git commit -am "chore: bump version to X.Y.Zb1"
-   git push origin dev
-   ```
-   Pushing to dev with a pre-release version triggers TestPyPI publish automatically.
+There is no pre-release/TestPyPI publishing path — it was removed as unnecessary. `dev`'s committed `pyproject.toml` version field is never bumped or read by anything; ignore it.
 
-**Production release to PyPI** (maintainers only):
-
-1. **Bump version** on dev to a stable version:
-   ```bash
-   git checkout dev
-   uv version --bump patch  # or minor, major
-   git commit -am "chore: bump version to X.Y.Z"
-   git push origin dev
-   ```
-
-2. **Create PR from dev to main**:
-   ```bash
-   gh pr create --base main --title "Release vX.Y.Z"
-   ```
-
-3. **Merge PR** — automated workflow handles:
-   - Runs tests on merged code
-   - Creates git tag (vX.Y.Z)
-   - Builds package
-   - Publishes to PyPI
-   - Creates GitHub Release
+Requires a `RELEASE_PLEASE_TOKEN` repo secret (fine-grained PAT with `contents:write` + `pull-requests:write`) so release-please's own commits trigger `test.yml` on its release PR — a push authenticated with the default `GITHUB_TOKEN` would not, and `main` requires that check to merge.
 
 ### CI Workflows
 
@@ -201,7 +175,7 @@ uv sync
 - Verifies linting passes after auto-fix
 - **Important**: Runs BEFORE test.yml, ensuring clean code for testing
 - **Scope**: Runs on dev, feature/** branches, and PRs to dev only
-- **Excluded**: Does NOT run on PRs to main (test.yml already verifies linting) or push to main (protected branch)
+- **Excluded**: Does NOT run on PRs to main (test.yml already verifies linting), push to main (protected branch), or release-please's managed branch (avoids racing its auto-generated PR)
 - **Files**: Only lints production code (`src/`) and tests (`tests/`), not examples or templates
 
 **test.yml** - Runs on PR to main/dev when code paths change:
@@ -218,15 +192,11 @@ uv sync
 - Docstring validation
 - Caches uv dependencies for speed
 - Cancels stale runs on new commits
+- Also runs on release-please's release PR, same as any other PR to main
 
-**release.yml** - Runs on PR merge to main with release label:
-- Tests before building
-- Extracts version from pyproject.toml
-- Determines publish target (PyPI/TestPyPI)
-- Creates and pushes git tag
-- Builds package with uv
-- Publishes via PyPI Trusted Publishing (OIDC, no API tokens)
-- Creates GitHub Release with PR notes and changelog
+**release.yml** - Runs on push to main:
+- `release-please` job: runs release-please-action, opens/updates the release PR
+- `publish-pypi` job: gated on `release_created`; builds with `uv build`, publishes via PyPI Trusted Publishing (OIDC), attaches build artifacts to the GitHub Release release-please already created (via `gh release upload`)
 
 **docs.yml** - Runs on push to main:
 - Generates API documentation with quartodoc
@@ -298,16 +268,7 @@ gh pr create --base main
 - Must pass before merge (critical for dependency changes)
 
 **Releases**:
-```bash
-git checkout -b release/v1.1.0
-uv version --bump minor
-git commit -am "chore: bump version to 1.1.0"
-gh pr create --base main --label release
-```
-- test.yml runs (pyproject.toml changed)
-- check-release-version.yml runs (release label)
-- Both must pass before merge
-- After merge: release.yml tags, builds, publishes to PyPI
+There's no manual release step — merge release-please's auto-maintained `chore(main): release X.Y.Z` PR whenever you're ready to ship. It updates itself as more commits land on `main`; just review the version/changelog and merge it like any other PR.
 
 ## Architecture Overview
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ feature-branches → dev → main (protected) → release (automated)
 - **Feature branches**: Create from `dev` for new work
 - **dev**: Integration branch for testing features
 - **main**: Protected production branch, requires PR with passing tests
-- **Releases**: Automated from `main` with labels
+- **Releases**: Fully automated via release-please, no labels needed
 
 ### Making Changes
 
@@ -130,53 +130,25 @@ Follow conventional commits format:
 
 **For Maintainers Only**
 
+Releases are fully automated via [release-please](https://github.com/googleapis/release-please) — there is no manual version bump, ever. The version number is computed entirely from conventional commit messages (`feat:`, `fix:`, `BREAKING CHANGE`) merged into `main` since the last release tag.
+
 ### Creating a Release
 
-1. **Bump version** on dev branch:
-   ```bash
-   git checkout dev
-   uv version --bump major  # or minor, patch
-   git commit -am "chore: bump version to X.Y.Z"
-   git push origin dev
-   ```
-
-2. **Create PR from dev to main**:
-   ```bash
-   gh pr create --base main --title "Release vX.Y.Z" --label release
-   ```
-
-   For TestPyPI testing, use `--label test-release` instead.
-
-3. **Version validation runs automatically**:
-   When you add the `release` or `test-release` label, a check runs to:
-   - ✅ Verify the tag doesn't already exist
-   - ✅ Validate semantic versioning format
-   - ✅ Check label matches version type
-   - ⚠️ **PR cannot merge if version was already released**
-
-4. **Add release notes** in PR description:
-   - Summarize major changes
-   - List breaking changes (if any)
-   - Mention contributors
-
-5. **Merge PR**:
-   - Ensure all tests pass
-   - Ensure version check passes
-   - Get required approvals
-   - Merge to main
-
-6. **Automated workflow**:
-   - Tests run on merged code
-   - Package builds and publishes to PyPI/TestPyPI
-   - Git tag created (vX.Y.Z)
-   - GitHub Release generated with PR notes
+1. **Merge feature work into `dev`**, then open a PR from `dev` to `main` and merge it, same as any other change.
+2. **release-please opens/updates a standing PR** on `main` titled `chore(main): release X.Y.Z`, containing the computed version bump and an auto-generated `CHANGELOG.md` entry. It keeps itself up to date as more commits land on `main` — no need to touch it until you're ready to ship.
+3. **Review that PR's diff** (just `pyproject.toml`, `CHANGELOG.md`, and the manifest file) and merge it whenever you want to cut a release.
+4. **Merging it automatically**:
+   - Creates the git tag (`vX.Y.Z`) and GitHub Release with the generated changelog as release notes
+   - Triggers `publish-pypi`, which builds the package and publishes to PyPI via Trusted Publishing (OIDC, no API tokens)
+   - Attaches the built `dist/*` artifacts to the GitHub Release
 
 ### Version Strategy
 
-- **Semantic Versioning**: MAJOR.MINOR.PATCH
-- **Pre-releases**: Use identifiers (rc, alpha, beta, dev)
-  - Example: `1.0.0rc1` automatically routes to TestPyPI
-  - Stable versions (e.g., `1.0.0`) go to production PyPI
+- **Semantic Versioning**: MAJOR.MINOR.PATCH, determined automatically:
+  - Any `feat:` commit since the last release → minor bump
+  - Any `BREAKING CHANGE` footer/`!` marker → major bump
+  - Otherwise, any `fix:` commit → patch bump
+- There is no pre-release/TestPyPI publishing path.
 
 ## CI/CD Workflows
 
@@ -186,23 +158,10 @@ Runs on every PR to `main`:
 - Tests (pytest)
 - Docstring validation
 
-### Release Version Check Workflow
-Runs when `release` or `test-release` label is added to PR:
-- Extracts version from `pyproject.toml`
-- Checks if tag already exists (blocks merge if yes)
-- Validates semantic versioning format
-- Warns if label doesn't match version type
-- Shows release target (PyPI vs TestPyPI)
-
-**Configure as required status check** to prevent merging releases with duplicate versions.
-
 ### Release Workflow
-Runs on PR merge to `main` with release label:
-- Runs tests
-- Builds package
-- Creates git tag
-- Publishes to PyPI/TestPyPI
-- Creates GitHub Release
+Runs on push to `main`:
+- `release-please` job opens/updates the standing release PR, computed from conventional commits
+- `publish-pypi` job (gated on a new release actually being created): builds the package, publishes to PyPI via Trusted Publishing (OIDC), attaches build artifacts to the GitHub Release
 
 ### Documentation Workflow
 Runs on push to `main` or `dev`:


### PR DESCRIPTION
The dev-branch TestPyPI publish job (`publish-testpypi`) served its purpose validating the release-please migration (#95/#96/#98), but there's no interest in maintaining a TestPyPI publish path going forward. This removes it entirely and narrows `release.yml`'s trigger to `main` only, since nothing in the workflow needs `dev` pushes anymore.

Also updates `CLAUDE.md` and `CONTRIBUTING.md`'s release-process sections to describe the release-please flow accurately (no manual version bump, no labels, no TestPyPI) instead of the old process — this was flagged as a follow-up in the original migration and there's no reason to defer it further now that the design is settled.

No functional risk: `publish-pypi`'s gating on `release_created` is untouched, and PR #97 (the in-flight release-please PR) is unaffected by this.